### PR TITLE
[CVE-2024-3393] Pan-OS DNS query - SNORT Detection

### DIFF
--- a/killchains/CVE-2024-3393/detection/snort/DoS-DNS-detect.snort
+++ b/killchains/CVE-2024-3393/detection/snort/DoS-DNS-detect.snort
@@ -1,9 +1,9 @@
 alert dns $EXTERNAL_NET any -> $EDGE_RTR any (
     msg:"Possible DNS attack";  
     reference:cve,2024-3393;
-    reference:url,https://github.com/TroutSoftware/eu-tis/issues/6;
+    reference:url,https://github.com/TroutSoftware/eu-tis/issues/5;
     sid:10000;
-    rev:1;
+    rev:2;
 
     content:"|0100|",depth 2,offset 2;
 )

--- a/killchains/CVE-2024-3393/detection/snort/DoS-DNS-detect.snort
+++ b/killchains/CVE-2024-3393/detection/snort/DoS-DNS-detect.snort
@@ -1,0 +1,10 @@
+alert dns $EXTERNAL_NET any -> $EDGE_RTR any (
+    msg:"Possible DNS attack";  
+    reference:cve,2024-3393;
+    reference:url,https://github.com/TroutSoftware/eu-tis/issues/6;
+    sid:10000;
+    rev:1;
+
+    content:"|0100|",depth 2,offset 2;
+)
+

--- a/killchains/CVE-2024-3393/detection/snort/DoS-DNS.snort
+++ b/killchains/CVE-2024-3393/detection/snort/DoS-DNS.snort
@@ -1,0 +1,13 @@
+stream = { }
+stream_ip = { }
+stream_icmp = { }
+stream_tcp = { }
+stream_udp = { }
+
+dns = { }
+
+binder = {
+  { when = { proto = 'udp', ports = '53', role='server' },  use = { type = 'dns' } }
+}
+
+ips = { include = 'DoS-DNS-detect.snort',variables = {  nets = {  EDGE_RTR = '192.168.100.62',  EXTERNAL_NET = 'any' } } } 

--- a/killchains/CVE-2024-3393/detection/yara/DNS_Query_Suspicious.yar
+++ b/killchains/CVE-2024-3393/detection/yara/DNS_Query_Suspicious.yar
@@ -1,0 +1,15 @@
+rule DOS_DNS_Suspicious
+{
+    meta:
+        description = "Detects suspicious DNS queries used in CVE-2024-3393"
+        cve = "CVE-2024-3393"
+        url = "https://github.com/TroutSoftware/eu-tis/issues/6"
+        author = "Trout"
+        date = "2024-02-11"
+
+    strings:
+        $dns_query_flag = { 00 01 }  
+
+    condition:
+        $dns_query_flag 
+}


### PR DESCRIPTION
Nothing in the vuln can be identified as a pattern.
Instead, I use a combination of (1) a request for dns on (2) a host that should not reply to those.

`content:"|0100|",depth 2,offset 2;`  match with DNS query HEADER (https://datatracker.ietf.org/doc/html/rfc1035)
