### PR TITLE
CVE-2024-55591 : FORTI-OS auth-bypass rules added

### DIFF
--- a/killchains/CVE-2024-55591/detection/snort/CVE-2024-55591-detect.snort
+++ b/killchains/CVE-2024-55591/detection/snort/CVE-2024-55591-detect.snort
@@ -1,0 +1,44 @@
+alert tcp $ANY_ADDRESS any -> $FORTIOS_ADDR any (
+    msg:"Possible FortiGate WebSocket CLI Pre-auth Access";
+    reference:cve,2024-55591;
+    reference:url,https://github.com/TroutSoftware/eu-tis/issues/7;
+    content:"GET /ws/cli/open";
+    content:"Upgrade: websocket";
+    classtype: FortiOS-activity;
+    sid:5559101;
+    rev:1;
+)
+
+alert tcp $ANY_ADDRESS any -> $FORTIOS_ADDR any ( 
+    msg:"Possible FortiGate Auth Bypass via local_access_token";
+    reference:cve,2024-55591;
+    reference:url,https://github.com/TroutSoftware/eu-tis/issues/7;
+    content:"local_access_token=";
+    classtype: FortiOS-activity;
+    sid:5559102;
+    rev:1;
+)
+
+alert tcp $ANY_ADDRESS any -> $FORTIOS_ADDR any (
+    msg:"Possible WebSocket Auth Bypass Detected";
+    reference:cve,2024-55591;
+    reference:url,https://github.com/TroutSoftware/eu-tis/issues/7;
+    content:"GET /ws/cli/open?cols=";
+    content:"local_access_token=";
+    classtype: FortiOS-activity;
+    sid:5559103;
+    rev:1;
+)
+
+# try to match a possible 
+alert tcp $ANY_ADDRESS any -> $FORTIOS_ADDR any (
+    msg:"Possible FortiGate Privilege Escalation via WebSocket Payload";
+    reference:cve,2024-55591;
+    reference:url,https://github.com/TroutSoftware/eu-tis/issues/7;
+    pcre:"/watchTowr|root|admin|super_admin/i";
+    classtype: FortiOS-activity;
+    sid:5559104;
+    rev:1;
+)
+
+

--- a/killchains/CVE-2024-55591/detection/snort/CVE-2024-55591.snort
+++ b/killchains/CVE-2024-55591/detection/snort/CVE-2024-55591.snort
@@ -1,0 +1,29 @@
+stream_user = { }
+stream_file = { }
+arp_spoof = { }
+
+http_inspect = { }
+
+dns = { }
+imap = { }
+normalizer = { }
+pop = { }
+rpc_decode = { }
+sip = { }
+ssh = { }
+ssl = { }
+telnet = { }    
+
+binder = {
+  { when = { proto = 'tcp', ports = '8080', role='server' }, use = { type = 'http_inspect' } },
+  { when = { proto = 'tcp', ports = '443', role='server' }, use = { type = 'ssl' } },
+}
+
+
+ips = { include = 'CVE-2024-55591-detect.snort',variables = {  nets = {  ANY_ADDRESS = 'any', FORTIOS_ADDR = '192.168.100.142' } } } 
+
+default_classifications =
+{
+    { name = 'FortiOS-activity', priority = 1,
+      text = 'Possible access to a potentially vulnerable FortiOS device' },
+}


### PR DESCRIPTION
Snort rules for the CVE-2024-55591 on Forti-OS leading to an Authentication Bypass , this vulnerability allows an unauthenticated attacker to gain super-admin privileges by exploiting a flaw in the Node.js WebSocket module (This affects the administrative interface). By sending specially crafted requests, a remote attacker can bypass authentication mechanisms, potentially taking full control of affected systems.


To counter this, we made some Snort rules trying to match the PCAP of the attack's reproduction. These rules look for suspicious HTTP requests to the WebSocket endpoint (/ws/cli/open) and the presence of a local_access_token= parameter, which indicates an attempt to bypass authentication. We also included a rule with a regex pattern to catch privilege escalation attempts by inspecting WebSocket payloads for keywords like root, admin, or super_admin. Each rule includes the appropriate CVE reference (CVE-2024-55591), a unique SID, and is classified as FortiOS-specific activity.